### PR TITLE
Update cats-parse to 0.3.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ ThisBuild / githubWorkflowPublish := Seq(
 
 val catsV = "2.6.1"
 val catsEffectV = "3.2.9"
-val catsParseV = "0.3.5"
+val catsParseV = "0.3.6"
 val http4sV = "0.23.6"
 val munitCatsEffectV = "1.0.6"
 


### PR DESCRIPTION
Hot off the presses: https://github.com/typelevel/cats-parse/releases/tag/v0.3.6