### PR TITLE
Use `.jsEnablePlugins(NpmPackagePlugin)`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ lazy val `curly` = project.in(file("."))
 // import .util.JSON._
 lazy val core = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
-  .enablePlugins(NpmPackagePlugin)
+  .jsEnablePlugins(NpmPackagePlugin)
   .in(file("core"))
   .settings(
     name := "curly4s",

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
 
   ).jsSettings(
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule)},
-    Compile / scalaJSUseMainModuleInitializer := true,
+    scalaJSUseMainModuleInitializer := true,
     scalaJSStage in Global := FullOptStage,
     npmPackageAuthor := "Christopher Davenport",
     npmPackageDescription := "Curl Command Line Parser which outputs http4s code",

--- a/build.sbt
+++ b/build.sbt
@@ -62,8 +62,8 @@ lazy val `curly` = project.in(file("."))
 // import .util.JSON._
 lazy val core = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
-  .jsEnablePlugins(NpmPackagePlugin)
   .in(file("core"))
+  .jsEnablePlugins(NpmPackagePlugin)
   .settings(
     name := "curly4s",
 

--- a/build.sbt
+++ b/build.sbt
@@ -75,6 +75,10 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
       "org.typelevel" %%% "munit-cats-effect-3" % munitCatsEffectV % Test,
     ),
 
+  ).jsSettings(
+    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule)},
+    scalaJSUseMainModuleInitializer := true,
+    scalaJSStage in Global := FullOptStage,
     npmPackageAuthor := "Christopher Davenport",
     npmPackageDescription := "Curl Command Line Parser which outputs http4s code",
     npmPackageKeywords := Seq(
@@ -84,10 +88,6 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
     ),
     npmPackageStage := Stage.FullOpt,
     npmPackageBinaryEnable := true,
-  ).jsSettings(
-    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule)},
-    scalaJSUseMainModuleInitializer := true,
-    scalaJSStage in Global := FullOptStage,
   )
 
 lazy val site = project.in(file("site"))

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
 
   ).jsSettings(
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule)},
-    scalaJSUseMainModuleInitializer := true,
+    Compile / scalaJSUseMainModuleInitializer := true,
     scalaJSStage in Global := FullOptStage,
     npmPackageAuthor := "Christopher Davenport",
     npmPackageDescription := "Curl Command Line Parser which outputs http4s code",


### PR DESCRIPTION
This PR fixes an issue with our `coreJVM` project still having ScalaJS inside and tests not running as expected.